### PR TITLE
Function to redraw all Lines

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@
     });
   }
 
-  function redraw(maintainAllPolyline) {
+  function redrawLines(maintainAllPolyline) {
     if (!maintainAllPolyline) {
       removeAllPolyline(map);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,10 +33,7 @@
       };
     }
 
-    setRandomPos(map);
-    layoutByForce();
-    setEdgePosition();
-    drawLine(map);
+    redrawLines(true);
 
     // event registrations
     map.on('zoomstart', function() {
@@ -44,27 +41,26 @@
     });
 
     map.on('zoomend', function() {
-      setRandomPos(map);
-      layoutByForce();
-      setEdgePosition();
-      drawLine(map);
+      redrawLines(true);
     });
 
     map.on('dragend', function() {
-      removeAllPolyline(map);
-      setRandomPos(map);
-      layoutByForce();
-      setEdgePosition();
-      drawLine(map);
+      redrawLines();
     });
 
     map.on('resize', function() {
-      removeAllPolyline(map);
-      setRandomPos(map);
-      layoutByForce();
-      setEdgePosition();
-      drawLine(map);
+      redrawLines();
     });
+  }
+
+  function redraw(maintainAllPolyline) {
+    if (!maintainAllPolyline) {
+      removeAllPolyline(map);
+    }
+    setRandomPos(map);
+    layoutByForce();
+    setEdgePosition();
+    drawLine(map);
   }
 
   function resetMarker(marker) {
@@ -320,6 +316,7 @@
   }
 
   TooltipLayout['initialize'] = initialize;
+  TooltipLayout['redrawLines'] = redrawLines;
   TooltipLayout['resetMarker'] = resetMarker;
   TooltipLayout['getMarkers'] = getMarkers;
   TooltipLayout['getLine'] = getLine;

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,6 +85,10 @@
     return markerList;
   }
 
+  function setMarkers(arr) {
+    markerList = arr;
+  }
+
   function getLine(marker) {
     return marker.__ply;
   }
@@ -319,6 +323,7 @@
   TooltipLayout['redrawLines'] = redrawLines;
   TooltipLayout['resetMarker'] = resetMarker;
   TooltipLayout['getMarkers'] = getMarkers;
+  TooltipLayout['setMarkers'] = setMarkers;
   TooltipLayout['getLine'] = getLine;
   TooltipLayout['removeAllPolyline'] = removeAllPolyline;
 


### PR DESCRIPTION
I wasn't happy calling the internal functions of L.tooltipLayout after my data has changed. So I made an internal `redrawLines()` function and used it also on the event listeners.